### PR TITLE
[Org Update] Update .NET to net8.0,net9.0,net10.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,23 +28,28 @@
   <ItemGroup>
     <None Include="..\..\Readme.md" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="Scriban" Version="6.5.0" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageVersion Include="Scriban" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="9.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+    <PackageVersion Include="Scriban" Version="6.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
@@ -54,8 +59,6 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageVersion Include="Scriban" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/dotnet-update-report.json
+++ b/dotnet-update-report.json
@@ -1,21 +1,105 @@
 {
-  "Timestamp": "2025-11-16 05:04:59",
+  "Summary": {
+    "DirectoryPackagesPropsUpdated": true,
+    "PackagesConfigured": 8,
+    "ProjectsUpdated": 8,
+    "PackagesChanged": 14,
+    "FrameworkSpecificGroups": 3,
+    "FrameworksSet": "net8.0;net9.0;net10.0"
+  },
   "PackagesFound": 8,
   "ProjectsFound": 8,
-  "ChangeSummaryText": "No package version changes - this might be a new setup or no updates available",
+  "Timestamp": "2025-11-16 16:47:29",
+  "ChangeSummaryText": "Microsoft.Extensions.Configuration.Abstractions [net8.0]: 8.0.0 -> 10.0.0\nMicrosoft.Extensions.Configuration.Abstractions [net9.0]: 9.0.11 -> 10.0.0\nMicrosoft.Extensions.DependencyInjection.Abstractions [net8.0]: 8.0.2 -> 10.0.0\nMicrosoft.Extensions.DependencyInjection.Abstractions [net9.0]: 9.0.11 -> 10.0.0\nMicrosoft.Extensions.Hosting [net8.0]: 8.0.1 -> 10.0.0\nMicrosoft.Extensions.Hosting [net9.0]: 9.0.11 -> 10.0.0\nMicrosoft.Extensions.Hosting.Abstractions [net8.0]: 8.0.1 -> 10.0.0\nMicrosoft.Extensions.Hosting.Abstractions [net9.0]: 9.0.11 -> 10.0.0\nMicrosoft.Extensions.Http [net8.0]: 8.0.1 -> 10.0.0\nMicrosoft.Extensions.Http [net9.0]: 9.0.11 -> 10.0.0\nMicrosoft.Extensions.Http.Resilience [net8.0]: 8.10.0 -> 10.0.0\nMicrosoft.Extensions.Http.Resilience [net9.0]: 9.10.0 -> 10.0.0\nMicrosoft.Extensions.Options.ConfigurationExtensions [net8.0]: 8.0.0 -> 10.0.0\nMicrosoft.Extensions.Options.ConfigurationExtensions [net9.0]: 9.0.11 -> 10.0.0",
+  "PackageChanges": [
+    {
+      "Package": "Microsoft.Extensions.Configuration.Abstractions",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.0",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.2",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Hosting",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.1",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Hosting.Abstractions",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.1",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Http",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.1",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Http.Resilience",
+      "Framework": "net8.0",
+      "OldVersion": "8.10.0",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Options.ConfigurationExtensions",
+      "Framework": "net8.0",
+      "OldVersion": "8.0.0",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Configuration.Abstractions",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.DependencyInjection.Abstractions",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Hosting",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Hosting.Abstractions",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Http",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Http.Resilience",
+      "Framework": "net9.0",
+      "OldVersion": "9.10.0",
+      "NewVersion": "10.0.0"
+    },
+    {
+      "Package": "Microsoft.Extensions.Options.ConfigurationExtensions",
+      "Framework": "net9.0",
+      "OldVersion": "9.0.11",
+      "NewVersion": "10.0.0"
+    }
+  ],
   "TargetFrameworks": [
     "net8.0",
     "net9.0",
     "net10.0"
-  ],
-  "PackageChanges": [],
-  "Summary": {
-    "CommonPackages": 1,
-    "FrameworkSpecificPackages": 7,
-    "PackagesConfigured": 8,
-    "ProjectsUpdated": 8,
-    "FrameworksSet": "net8.0;net9.0;net10.0",
-    "PackagesChanged": 0,
-    "DirectoryPackagesPropsUpdated": true
-  }
+  ]
 }


### PR DESCRIPTION
### Organization-Wide .NET Update

This PR was created as part of an organization-wide .NET update.

**Target Frameworks:** `net8.0,net9.0,net10.0`

**Tracking Issue:** https://github.com/Zonit/.github/issues/18

---

#### What Changed:
- **Projects Updated:** 8
- **Packages Configured:** 8
- **Package Versions Changed:** 14
- **Common Packages:** COMMON_8
- **Framework-Specific Packages:** 0
- **Target Frameworks:** `net8.0;net9.0;net10.0`
- **Central Package Management:** Enabled


**The following NuGet packages were updated:**

```
Microsoft.Extensions.Configuration.Abstractions [net8.0]: 8.0.0 -> 10.0.0
Microsoft.Extensions.Configuration.Abstractions [net9.0]: 9.0.11 -> 10.0.0
Microsoft.Extensions.DependencyInjection.Abstractions [net8.0]: 8.0.2 -> 10.0.0
Microsoft.Extensions.DependencyInjection.Abstractions [net9.0]: 9.0.11 -> 10.0.0
Microsoft.Extensions.Hosting [net8.0]: 8.0.1 -> 10.0.0
Microsoft.Extensions.Hosting [net9.0]: 9.0.11 -> 10.0.0
Microsoft.Extensions.Hosting.Abstractions [net8.0]: 8.0.1 -> 10.0.0
Microsoft.Extensions.Hosting.Abstractions [net9.0]: 9.0.11 -> 10.0.0
Microsoft.Extensions.Http [net8.0]: 8.0.1 -> 10.0.0
Microsoft.Extensions.Http [net9.0]: 9.0.11 -> 10.0.0
Microsoft.Extensions.Http.Resilience [net8.0]: 8.10.0 -> 10.0.0
Microsoft.Extensions.Http.Resilience [net9.0]: 9.10.0 -> 10.0.0
Microsoft.Extensions.Options.ConfigurationExtensions [net8.0]: 8.0.0 -> 10.0.0
Microsoft.Extensions.Options.ConfigurationExtensions [net9.0]: 9.0.11 -> 10.0.0
```

---

**Next Steps:**
1. Review changes
2. Run `dotnet restore`
3. Run `dotnet build`
4. Run tests
5. Merge when ready

**Part of:** Organization-wide .NET update
**Tracking:** https://github.com/Zonit/.github/issues/18
